### PR TITLE
Add archive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The easiest and best way of running kubebck is by using `Docker`. You need to pr
 ```
 docker run \
   -d --privileged \
-  -v /var/lib/kubebck/data/:/kubebck 
-  -v /var/lib/kubebck/config:/config 
+  -v /var/lib/kubebck/data/:/kubebck \
+  -v /var/lib/kubebck/config:/config \
   amimof/kubebck:latest
 ```
 This example will connect to the Kubernetes clusters using the contexts defined in the provided kubeconfig file and store exported data to `/var/lib/kubebck/data` on the container host. After the kubebck container is finished backing up all clusters, the container will terminate and the content of the output directory will look something like this.

--- a/run.sh
+++ b/run.sh
@@ -14,18 +14,19 @@ function error {
 }
 
 # Set some variables to be used later on
-DATE=`date "+%F"`
+DATE=`date "+%F_%H%M"`
 KUBECONFIG="${KUBECONFIG:-"/config"}"
 export KUBECONFIG=$KUBECONFIG
 CONTEXTS=$(kubectl config get-contexts --no-headers -o name)
 CONTEXTS_COUNT=$(echo $CONTEXTS | wc -w)
 OUTPUT_DIR="${OUTPUT_DIR:-"/kubebck"}"
 OUTPUT_FORMAT="${OUTPUT_FORMAT:-"yaml"}"
+KUBEBCK_ARCHIVE="${KUBEBCK_ARCHIVE:-"false"}"
 
 # Print out some informative info
 info "Output path is: ${OUTPUT_DIR}"
+info "KUBECONFIG=${KUBECONFIG}"
 info "Contexts in kubeconfig: ${CONTEXTS_COUNT}"
-
 
 for CONTEXT in $CONTEXTS; do 
 
@@ -75,6 +76,15 @@ for CONTEXT in $CONTEXTS; do
       kubectl get $API -n ${NAMESPACE} --no-headers --ignore-not-found -o $OUTPUT_FORMAT > $FILE_NAME
     done
   done
+
+  # Tar context output dir if desired
+  if [ "$KUBEBCK_ARCHIVE" == "true" ]; then
+    ARCHIVE_FILE_NAME="${OUTPUT_DIR}/${CONTEXT}/${CONTEXT}_${DATE}.tar.gz"
+    info "Creating archive ${ARCHIVE_FILE_NAME}"
+    tar -zcf "${ARCHIVE_FILE_NAME}" "${CONTEXT_OUTPUT_DIR}"
+    chmod +x ${ARCHIVE_FILE_NAME}
+    rm -r "${CONTEXT_OUTPUT_DIR}"
+  fi
 
   info "Done exporting ${CONTEXT}"
 


### PR DESCRIPTION
* Set `KUBEBCK_ARCHIVE` to create a tar of the entire output directory and then remove the output directory after the archive is created.
* Resulting dir will look like this
```
├── minikube
         └── minikube_2019-04-08_1146.tar.gz
```
* One tar file for each export run including `<clustername>_<date>_<hours><minute>.tar.gz`